### PR TITLE
bitcore-build-dash dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 
 
-var bitcoreTasks = require('bitcore-build');
+var bitcoreTasks = require('bitcore-build-dash');
 
 bitcoreTasks('lib');

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -153,7 +153,7 @@ var livenet = get('livenet');
 addNetwork({
   name: 'testnet',
   alias: 'regtest',
-  pubkeyhash: 0x8C,
+  pubkeyhash: 0x8c,
   privatekey: 0xef,
   scripthash: 0x13,
   xpubkey: 0x3a8061a0,

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -153,7 +153,7 @@ var livenet = get('livenet');
 addNetwork({
   name: 'testnet',
   alias: 'regtest',
-  pubkeyhash: 0x8b,
+  pubkeyhash: 0x8C,
   privatekey: 0xef,
   scripthash: 0x13,
   xpubkey: 0x3a8061a0,

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/UdjinM6/bitcore-lib-dash.git"
+    "url": "https://github.com/dashpay/bitcore-lib-dash.git"
   },
   "browser": {
     "request": "browser-request"
@@ -94,7 +94,8 @@
     "x11-hash": "git://github.com/zone117x/node-x11-hash.git#c7b65aa08ea44861d5739e2d5404cfc939ede55b"
   },
   "devDependencies": {
-    "bitcore-build": "bitpay/bitcore-build",
+    "bitcore-build-dash": "dashpay/bitcore-build",
+    "browserify": "latest",
     "brfs": "^1.2.0",
     "chai": "^1.10.0",
     "gulp": "^3.8.10",


### PR DESCRIPTION
small update to point the bitcore-build-dash dependency to dashpay/bitcore-build-dash